### PR TITLE
Adds jekyllStyleLayout config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ Metalsmith(__dirname)
     .build();
 ```
 
+### jekyllStyleLayout option
+
+`metalsmith-mallet` uses the jekyll `layout: post` syntax for layouts, adding a `.html` extension by default. You can override this behaviour by setting `jekyllStyleLayout` to `false`.
+
+```js
+Metalsmith(__dirname)
+    .use(mallet({ jekyllStyleLayout: false }))
+    .use(markdown())
+    .build();
+```
+
 In addition to properties defined in the YAML Front Matter metalsmith-mallet defines `url` and `date`, so in a Handlebars template you can do something like this:
 
 ```html

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ var isIgnored = function (file, blacklist) {
  * @return {Object}             Default: { ignore: [] }
  */
 var mergeOptions = function (userOptions) {
-  var defaultOptions = { ignore: [], collection: null };
+  var defaultOptions = { ignore: [], collection: null, jekyllStyleLayout: true };
 
   for (var opt in userOptions) defaultOptions[opt] = userOptions[opt];
 
@@ -89,8 +89,10 @@ module.exports = function (options) {
         data.date   = parts.date;
         data.url    = '/' + dir + '/' + parts.url;
 
-        // Metalsmith uses a different template property.
-        data.template   = data.layout + '.html';
+        if (options.jekyllStyleLayout) {
+          // Metalsmith uses a different template property.
+          data.template   = data.layout + '.html';
+        }
 
         // Make it easier to use mallet plugin together with collections plugin,
         // which requires either a pattern or a collection property. mallet

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-mallet",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A Metalsmith plugin to build Jekyll style posts.",
   "homepage": "https://github.com/aigarsdz/metalsmith-mallet",
   "repository" : {


### PR DESCRIPTION
Provide an option to opt out of using `layout: post`.

Original behaviour is still default.
